### PR TITLE
Updated syntax to 0.15+ (master) level

### DIFF
--- a/semver/solver/in_mem_artifact_source.pony
+++ b/semver/solver/in_mem_artifact_source.pony
@@ -12,7 +12,7 @@ class InMemArtifactSource is ArtifactSource
     try
       artifactSetsByName(a.name).set(a)
     else
-      artifactSetsByName(a.name) = Set[Artifact].set(a)
+      artifactSetsByName(a.name) = Set[Artifact].>set(a)
     end
 
   fun ref allVersionsOf(name: String): Iterator[Artifact] =>

--- a/semver/solver/solver.pony
+++ b/semver/solver/solver.pony
@@ -57,7 +57,7 @@ class Solver
 
         if (firstConflict is None) then
           firstConflict = _ConflictSnapshot(
-            Array[_Cell].concat(activatedCellsByName.values()),
+            Array[_Cell].>concat(activatedCellsByName.values()),
             pCell.constraint,
             pCell.parent
           )
@@ -69,7 +69,7 @@ class Solver
         while true do
           match cell
           | let c: _Cell =>
-            let ranges = Array[Range].push(c.constraint.range)
+            let ranges = Array[Range].>push(c.constraint.range)
 
             // Blend in the constraint that kicked this backtracking off
             if (conflictingConstraint.artifactName == c.constraint.artifactName) then
@@ -98,19 +98,19 @@ class Solver
       try result.solution.push(cell.picks(0)) end
     end
     result
-  
+
   fun ref _allVersionsOf(artifactName: String): Array[Artifact] =>
     // copy for isolation
-    let versions = Array[Artifact].concat(source.allVersionsOf(artifactName))
+    let versions = Array[Artifact].>concat(source.allVersionsOf(artifactName))
     // reverse sort to make all the 'default to latest' optimizations work
     col.Sort[Array[Artifact], Artifact](versions).reverse()
-  
+
   fun _indexOfFirstMatch(artifacts: Array[Artifact], ranges: Seq[Range]): (USize, Bool) =>
     for (i, a) in artifacts.pairs() do
       var allMatch = true
 
       for r in ranges.values() do
-        if (not r.contains(a.version)) then 
+        if (not r.contains(a.version)) then
           allMatch = false
           break
         end
@@ -120,7 +120,7 @@ class Solver
     end
 
     (0, false)
-  
+
   fun _pick(cell: _Cell, index: USize, newCells: Array[_Cell]) =>
     cell.picks = cell.picks.slice(index)
 

--- a/semver/version/compare_versions.pony
+++ b/semver/version/compare_versions.pony
@@ -3,11 +3,11 @@ use "../../utils"
 primitive CompareVersions
   fun apply(v1: Version box, v2: Version box): Compare =>
     let heads = [
-      (v1.major, v2.major),
-      (v1.minor, v2.minor),
+      (v1.major, v2.major)
+      (v1.minor, v2.minor)
       (v1.patch, v2.patch)
     ]
-    
+
     for (h1, h2) in heads.values() do
       if (h1 != h2) then return h1.compare(h2) end
     end

--- a/semver/version/consts.pony
+++ b/semver/version/consts.pony
@@ -4,8 +4,13 @@ use "collections"
 //       the runtime cost here every time is silly for what are supposed to be fixed values
 primitive Consts
   fun alphas(): Set[U8] =>
-    Set[U8].union("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-".values())
+    Set[U8].>
+      union("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz-".values())
+
   fun nums(): Set[U8] =>
-    Set[U8].union("0123456789".values())
+    Set[U8].>union("0123456789".values())
+
   fun alphanums(): Set[U8] =>
-    Set[U8].union(alphas().values()).union(nums().values())
+    Set[U8].>
+      union(alphas().values()).>
+      union(nums().values())

--- a/semver/version/version.pony
+++ b/semver/version/version.pony
@@ -25,7 +25,7 @@ class Version is (ComparableMixin[Version] & Hashable & Stringable)
 
   fun compare(that: Version box): Compare =>
     CompareVersions(this, that)
-  
+
   fun hash(): U64 =>
     string().hash()
 
@@ -48,8 +48,8 @@ class Version is (ComparableMixin[Version] & Hashable & Stringable)
     result
 
   fun majorMinorPatchString(): String =>
-    ".".join([major, minor, patch])
-  
+    ".".join([major; minor; patch])
+
   fun preReleaseString(): String =>
     ".".join(prFields)
 

--- a/test/range/test_range_inclusion_rules.pony
+++ b/test/range/test_range_inclusion_rules.pony
@@ -11,15 +11,15 @@ class TestRangeInclusionRules is UnitTest
     let v2 = ParseVersion("2.0.0")
 
     let incTests = [
-      (Range(v1, v2), true, true),
-      (Range(v1, v2, false, false), false, false),
-      (Range(None, v2, false, false), true, false),
-      (Range(v1, None, false, false), false, true),
+      (Range(v1, v2), true, true)
+      (Range(v1, v2, false, false), false, false)
+      (Range(None, v2, false, false), true, false)
+      (Range(v1, None, false, false), false, true)
       (Range(v1, v1, false, false), true, true)
     ]
 
     for (vr, fromInc, toInc) in incTests.values() do
-      h.assert_array_eq[Bool]([fromInc, toInc], [vr.fromInc, vr.toInc],
+      h.assert_array_eq[Bool]([fromInc; toInc], [vr.fromInc; vr.toInc],
         "from=" + vr.from.string() +
         ", to=" + vr.to.string()
       )

--- a/test/range/test_range_matching.pony
+++ b/test/range/test_range_matching.pony
@@ -15,17 +15,17 @@ class TestRangeMatching is UnitTest
     let v4 = ParseVersion("4.0.0")
 
     let conTests = [
-      (Range(v1, v3), [false, true, true, true, false]),
-      (Range(v1, v3, false), [false, false, true, true, false]),
-      (Range(v1, v3, true, false), [false, true, true, false, false]),
-      (Range(v1, v3, false, true), [false, false, true, true, false]),
-      (Range(v1, v3, false, false), [false, false, true, false, false]),
-      (Range(None, v3), [true, true, true, true, false]),
-      (Range(v1, None), [false, true, true, true, true]),
-      (Range(None, None), [true, true, true, true, true])
+      (Range(v1, v3), [false; true; true; true; false])
+      (Range(v1, v3, false), [false; false; true; true; false])
+      (Range(v1, v3, true, false), [false; true; true; false; false])
+      (Range(v1, v3, false, true), [false; false; true; true; false])
+      (Range(v1, v3, false, false), [false; false; true; false; false])
+      (Range(None, v3), [true; true; true; true; false])
+      (Range(v1, None), [false; true; true; true; true])
+      (Range(None, None), [true; true; true; true; true])
     ]
 
-    let conTestVersions = [v0, v1, v2, v3, v4]
+    let conTestVersions = [v0; v1; v2; v3; v4]
 
     for (vr, expecteds) in conTests.values() do
       for (e, v) in ZipIterator[Bool, Version](expecteds.values(), conTestVersions.values()) do

--- a/test/range/test_range_merging.pony
+++ b/test/range/test_range_merging.pony
@@ -14,12 +14,12 @@ class TestRangeMerging is UnitTest
     let v4 = ParseVersion("4.0.0")
 
     let mergeTests = [
-      (Range(v1, v2), Range(v2, v3), Range(v1, v3)),
-      (Range(v1, v2), Range(v3, v4), Range(v1, v4)),
-      (Range(v1, v2, true, false), Range(v1, v2, false, true), Range(v1, v2)),
-      (Range(v2, v3), Range(v1, v4), Range(v1, v4)),
-      (Range(None, v1), Range(v0, v2), Range(None, v2)),
-      (Range(v1, None), Range(v0, v2), Range(v0, None)),
+      (Range(v1, v2), Range(v2, v3), Range(v1, v3))
+      (Range(v1, v2), Range(v3, v4), Range(v1, v4))
+      (Range(v1, v2, true, false), Range(v1, v2, false, true), Range(v1, v2))
+      (Range(v2, v3), Range(v1, v4), Range(v1, v4))
+      (Range(None, v1), Range(v0, v2), Range(None, v2))
+      (Range(v1, None), Range(v0, v2), Range(v0, None))
       (Range(None, v1), Range(v0, None), Range(None, None))
     ]
 

--- a/test/range/test_range_overlap_detection.pony
+++ b/test/range/test_range_overlap_detection.pony
@@ -14,11 +14,11 @@ class TestRangeOverlapDetection is UnitTest
     let v4 = ParseVersion("4.0.0")
 
     let overlapTests = [
-      (Range(v1, v2), Range(v2, v3), true),
-      (Range(v1, v2), Range(v2, v3, false), false),
-      (Range(v1, v3, true, false), Range(v2, v3, false, false), true),
-      (Range(None, v3), Range(v0, v4), true),
-      (Range(v2, None), Range(v3, v4), true),
+      (Range(v1, v2), Range(v2, v3), true)
+      (Range(v1, v2), Range(v2, v3, false), false)
+      (Range(v1, v3, true, false), Range(v2, v3, false, false), true)
+      (Range(None, v3), Range(v0, v4), true)
+      (Range(v2, None), Range(v3, v4), true)
       (Range(None, None), Range(None, None), true)
     ]
 

--- a/test/solver/test_solver_engine.pony
+++ b/test/solver/test_solver_engine.pony
@@ -27,7 +27,7 @@ class Scenario
 class TestSolverEngine is UnitTest
   fun name(): String =>
     "SolverEngine"
-  
+
   fun apply(h: TestHelper) ? =>
     let scenariosPath = FilePath(h.env.root as AmbientAuth, "test/solver/scenarios")
 
@@ -46,11 +46,11 @@ class TestSolverEngine is UnitTest
       if (line.at("#")) then continue end
 
       if (not line.at("\t")) then
-        section = line.clone().strip()
+        section = line.clone().>strip()
         continue
       end
 
-      let l = line.clone().strip()
+      let l = recover ref line.clone().>strip() end
 
       match section
       | "Available" =>
@@ -67,7 +67,7 @@ class TestSolverEngine is UnitTest
     end
 
     scenario
-  
+
   fun parseArtifact(id: String box, depList: String box): Artifact ? =>
     let deps = Array[Constraint]
     for dep in depList.split(",").values() do
@@ -76,9 +76,9 @@ class TestSolverEngine is UnitTest
 
     let idParts = id.split("@")
     Artifact(idParts(0), ParseVersion(idParts(1)), deps)
-  
+
   fun parseConstraint(c: String box): Constraint ? =>
-    for rel in ["<=", "<", ">=", ">", "="].values() do
+    for rel in ["<="; "<"; ">="; ">"; "="].values() do
       try
         let relIndex = c.find(rel)
         let cParts = c.split_by(rel)

--- a/test/solver/test_solver_support_classes.pony
+++ b/test/solver/test_solver_support_classes.pony
@@ -7,7 +7,7 @@ use "../../semver/version"
 class TestSolverSupportClasses is UnitTest
   fun name(): String =>
     "SolverSupportClasses"
-  
+
   fun apply(h: TestHelper) =>
     // Constraint
 
@@ -17,7 +17,7 @@ class TestSolverSupportClasses is UnitTest
     )
 
     // Artifact
-    
+
     let a1 = Artifact("foo", Version(1),
       [Constraint("bar", Range(Version(1), Version(2)))]
     )
@@ -37,14 +37,14 @@ class TestSolverSupportClasses is UnitTest
     // Artifact Source
 
     let source = InMemArtifactSource
-    h.assert_eq[USize](0, Array[Artifact].concat(source.allVersionsOf("foo")).size())
+    h.assert_eq[USize](0, Array[Artifact].>concat(source.allVersionsOf("foo")).size())
 
     source.add(Artifact("foo", Version(1)))
     source.add(Artifact("foo", Version(2)))
-    h.assert_eq[USize](2, Array[Artifact].concat(source.allVersionsOf("foo")).size())
+    h.assert_eq[USize](2, Array[Artifact].>concat(source.allVersionsOf("foo")).size())
 
     source.add(Artifact("foo", Version(1), [Constraint("bar", Range(None, None))]))
-    h.assert_eq[USize](2, Array[Artifact].concat(source.allVersionsOf("foo")).size())
+    h.assert_eq[USize](2, Array[Artifact].>concat(source.allVersionsOf("foo")).size())
     for a in source.allVersionsOf("foo") do
       if (a.version == Version(1)) then
         h.assert_eq[USize](1, a.dependsOn.size())

--- a/test/version/test_version_comparison.pony
+++ b/test/version/test_version_comparison.pony
@@ -10,21 +10,21 @@ class TestVersionComparison is UnitTest
 
     let tests = [
       // major
-      ("1.0.0", "1.0.0", Equal) as (String, String, Compare), // hints compiler
-      ("2.0.0", "1.0.0", Greater),
+      ("1.0.0", "1.0.0", Equal) as (String, String, Compare) // hints compiler
+      ("2.0.0", "1.0.0", Greater)
       // minor
-      ("1.2.0", "1.2.0", Equal),
-      ("1.3.0", "1.2.0", Greater),
+      ("1.2.0", "1.2.0", Equal)
+      ("1.3.0", "1.2.0", Greater)
       // patch
-      ("1.2.3", "1.2.3", Equal),
-      ("1.2.4", "1.2.3", Greater),
+      ("1.2.3", "1.2.3", Equal)
+      ("1.2.4", "1.2.3", Greater)
       // pre-release
-      ("1.2.3-foo", "1.2.3", Less),
-      ("1.2.3-foo", "1.2.3-foo", Equal),
-      ("1.2.3-foo.0", "1.2.3-foo.1", Less),
-      ("1.2.3-foo.0", "1.2.3-foo.a", Less),
-      ("1.2.3-foo.a", "1.2.3-foo.b", Less),
-      ("1.2.3-foo.a", "1.2.3-foo.a", Equal),
+      ("1.2.3-foo", "1.2.3", Less)
+      ("1.2.3-foo", "1.2.3-foo", Equal)
+      ("1.2.3-foo.0", "1.2.3-foo.1", Less)
+      ("1.2.3-foo.0", "1.2.3-foo.a", Less)
+      ("1.2.3-foo.a", "1.2.3-foo.b", Less)
+      ("1.2.3-foo.a", "1.2.3-foo.a", Equal)
       ("1.2.3-foo.a", "1.2.3-foo.a.b", Less)
     ]
 

--- a/test/version/test_version_parsing.pony
+++ b/test/version/test_version_parsing.pony
@@ -28,25 +28,25 @@ class TestVersionParsing is UnitTest
     let v6 = ParseVersion("1.2.3-pre.$..01.0a.0.1")
     h.assert_false(v6.isValid())
     h.assert_array_eq[String]([
-      "numeric pre-release fields cannot have leading zeros",
-      "pre-release field 2 contains non-alphanumeric characters",
+      "numeric pre-release fields cannot have leading zeros"
+      "pre-release field 2 contains non-alphanumeric characters"
       "pre-release field 3 is blank"
     ], v6.errors)
 
     let v7 = ParseVersion("1.2.3+build.$..1")
     h.assert_false(v7.isValid())
     h.assert_array_eq[String]([
-      "build field 2 contains non-alphanumeric characters",
+      "build field 2 contains non-alphanumeric characters"
       "build field 3 is blank"
     ], v7.errors)
 
     let v8 = ParseVersion("1.2.3-pre.$..01.0a.0.1+build.$..1")
     h.assert_false(v8.isValid())
     h.assert_array_eq[String]([
-      "numeric pre-release fields cannot have leading zeros",
-      "pre-release field 2 contains non-alphanumeric characters",
-      "pre-release field 3 is blank",
-      "build field 2 contains non-alphanumeric characters",
+      "numeric pre-release fields cannot have leading zeros"
+      "pre-release field 2 contains non-alphanumeric characters"
+      "pre-release field 3 is blank"
+      "build field 2 contains non-alphanumeric characters"
       "build field 3 is blank"
     ], v8.errors)
 
@@ -61,4 +61,4 @@ class TestVersionParsing is UnitTest
     h.assert_eq[String]("0a", v9.prFields(1) as String)
     h.assert_eq[U64](0, v9.prFields(2) as U64)
     h.assert_eq[U64](1, v9.prFields(3) as U64)
-    h.assert_array_eq[String](["build", "1"], v9.buildFields)
+    h.assert_array_eq[String](["build"; "1"], v9.buildFields)

--- a/test/version/test_version_stringification.pony
+++ b/test/version/test_version_stringification.pony
@@ -18,19 +18,19 @@ class TestVersionStringification is UnitTest
     h.assert_eq[String]("", v2.buildString())
     h.assert_eq[String]("2.3.4", v2.string())
 
-    let v3 = Version(where major' = 3, prFields' = ["alpha", 0, "beta"])
+    let v3 = Version(where major' = 3, prFields' = ["alpha"; 0; "beta"])
     h.assert_eq[String]("3.0.0", v3.majorMinorPatchString())
     h.assert_eq[String]("alpha.0.beta", v3.preReleaseString())
     h.assert_eq[String]("", v3.buildString())
     h.assert_eq[String]("3.0.0-alpha.0.beta", v3.string())
 
-    let v4 = Version(where major' = 4, buildFields' = ["buildinfo", "morebuildinfo"])
+    let v4 = Version(where major' = 4, buildFields' = ["buildinfo"; "morebuildinfo"])
     h.assert_eq[String]("4.0.0", v4.majorMinorPatchString())
     h.assert_eq[String]("", v4.preReleaseString())
     h.assert_eq[String]("buildinfo.morebuildinfo", v4.buildString())
     h.assert_eq[String]("4.0.0+buildinfo.morebuildinfo", v4.string())
 
-    let v5 = Version(where major' = 5, prFields' = ["alpha", 0, "beta"], buildFields' = ["buildinfo", "morebuildinfo"])
+    let v5 = Version(where major' = 5, prFields' = ["alpha"; 0; "beta"], buildFields' = ["buildinfo"; "morebuildinfo"])
     h.assert_eq[String]("5.0.0", v5.majorMinorPatchString())
     h.assert_eq[String]("alpha.0.beta", v5.preReleaseString())
     h.assert_eq[String]("buildinfo.morebuildinfo", v5.buildString())

--- a/test/version/test_version_validation.pony
+++ b/test/version/test_version_validation.pony
@@ -4,17 +4,17 @@ use "../../semver/version"
 class TestVersionValidation is UnitTest
   fun name(): String =>
     "VersionValidation"
-  
+
   fun apply(h: TestHelper) =>
     let v1 = Version(1)
     h.assert_true(v1.isValid())
 
-    let v2 = Version(where major' = 1, prFields' = ["good", "b$d", "", 1, "fine"], buildFields' = ["good", "b$d", "", "fine"])
+    let v2 = Version(where major' = 1, prFields' = ["good"; "b$d"; ""; 1; "fine"], buildFields' = ["good"; "b$d"; ""; "fine"])
     h.assert_false(v2.isValid())
     h.assert_array_eq[String]([
-        "pre-release field 2 contains non-alphanumeric characters",
-        "pre-release field 3 is blank",
-        "build field 2 contains non-alphanumeric characters",
+        "pre-release field 2 contains non-alphanumeric characters"
+        "pre-release field 3 is blank"
+        "build field 2 contains non-alphanumeric characters"
         "build field 3 is blank"
       ],
       v2.errors


### PR DESCRIPTION
Hey Andre! Your library looks like a very useful component for the dependency manager tool that I'm building. I thought I'd bring it up to date for you since there have been a couple of breaking syntax changes in Pony. 

The changes are:
 - Using method chaining operator to obtain receiver
 - Using ';' in array initializers

See:
 - https://github.com/ponylang/rfcs/blob/master/text/0025-sugar-for-method-chaining.md
 - https://github.com/ponylang/rfcs/blob/master/text/0037-arrays-as-sequences.md
