### PR TITLE
Change name from pony-semver to semver

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-You want to contribute to pony-semver? Awesome.
+You want to contribute to semver? Awesome.
 
 There are a number of ways to contribute. As this document is a little long, feel free to jump to the section that applies to you currently:
 
@@ -14,7 +14,7 @@ There are a number of ways to contribute. As this document is a little long, fee
 
 ## Bug report
 
-First of all please [search existing issues](https://github.com/ponylang/pony-semver/issues) to make sure your issue hasn't already been reported. If you cannot find a suitable issue — [create a new one](https://github.com/ponylang/pony-semver/issues/new).
+First of all please [search existing issues](https://github.com/ponylang/semver/issues) to make sure your issue hasn't already been reported. If you cannot find a suitable issue — [create a new one](https://github.com/ponylang/semver/issues/new).
 
 Provide the following details:
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pony-semver
+# semver
 
 A semantic versioning library and constraints solver for Ponylang heavily inspired by [blang/semver](https://github.com/blang/semver).
 


### PR DESCRIPTION
No need for the leading "pony" given its under the ponylang organization.