### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/semver/test/version/test_version_comparison.pony
+++ b/semver/test/version/test_version_comparison.pony
@@ -32,7 +32,7 @@ class \nodoc\ TestVersionComparison is UnitTest
       let v1 = ParseVersion(v1s)
       let v2 = ParseVersion(v2s)
       let expectedInverse =
-        match expected
+        match \exhaustive\ expected
         | Less => Greater
         | Equal => Equal
         | Greater => Less


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.