### PR TITLE
Fix build failure with recent Pony compilers

### DIFF
--- a/.release-notes/fix-build-exhaustive-match.md
+++ b/.release-notes/fix-build-exhaustive-match.md
@@ -1,0 +1,3 @@
+## Fix build failure with recent Pony compilers
+
+Recent Pony compilers reject `else` branches on `match` expressions that are already exhaustive. The version comparison code had such an `else` as a legacy workaround, so semver wouldn't build. That's been cleaned up.

--- a/semver/version/compare_versions.pony
+++ b/semver/version/compare_versions.pony
@@ -29,11 +29,9 @@ primitive CompareVersions
     p1s.compare(p2s)
 
   fun _compare_pr_Fields(p1: PreReleaseField, p2: PreReleaseField): Compare =>
-    match (p1, p2)
+    match \exhaustive\ (p1, p2)
     | (let u1: U64, let s2: String) => Less
     | (let s1: String, let u2: U64) => Greater
     | (let u1: U64, let u2: U64) => u1.compare(u2)
     | (let s1: String, let s2: String) => s1.compare(s2)
-    else
-      Equal // should never get here but compiler complains without it
     end


### PR DESCRIPTION
Recent Pony compilers reject `else` branches on `match` expressions that are already exhaustive. The `_compare_pr_Fields` match in `semver/version/compare_versions.pony` enumerates all four shape combinations of `(U64 | String, U64 | String)`, but carried a dead `else Equal` branch as a legacy workaround with the comment "should never get here but compiler complains without it." With the stricter check, the compiler now correctly errors instead, so semver no longer builds.

Added `\exhaustive\` to the match and removed the dead branch. Full test suite passes.