### PR TITLE
Fix image tag in ponyc breakage workflow

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test against ponyc main
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:latest
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test


### PR DESCRIPTION
The breakage workflow was referencing `shared-docker-ci-standard-builder:latest`, but that image only publishes `:release` and `:nightly` — no `:latest` tag exists. Every `shared-docker-builders-updated` dispatch since the tag regressed has failed at container pull with `manifest unknown`, and because the `if: failure()` alert step runs inside the same container, no Zulip notification fired either. The workflow was silently doing nothing.

`:nightly` is what the workflow actually wants (build against ponyc main) and matches what every peer ponylang repo uses.

Seen in https://github.com/ponylang/semver/actions/runs/24166786044.